### PR TITLE
Fix ripple animation

### DIFF
--- a/material-yewi/src/button_base/ripples.rs
+++ b/material-yewi/src/button_base/ripples.rs
@@ -222,7 +222,7 @@ pub fn ripples(props: &RipplesProp) -> Html {
                 gloo::timers::callback::Timeout::new(550, move || {
                     ripples_capture.dispatch(Box::new(move |v| {
                         if let Some(p) = v.iter().position(|v| v.0 == ripple_id) {
-                            v.swap_remove(p);
+                            v.remove(p);
                         }
                     }));
                 })


### PR DESCRIPTION
When multiple ripples are present, `swap_remove` would reorder them, restarting some animations after the rerender.